### PR TITLE
過剰なメモ化を除去して、エラーを解決

### DIFF
--- a/src/components/darkModeButton.tsx
+++ b/src/components/darkModeButton.tsx
@@ -4,7 +4,7 @@ import { TitleStyle } from '@/utils/styleComponents';
 import { useAtom } from 'jotai';
 import { darkModeAtom } from '@/globalStates/darkModeAtom';
 
-export const DarkModeButton = memo(() => {
+export const DarkModeButton = () => {
   const [isDarkMode, setIsDarkMode] = useAtom(darkModeAtom);
 
   const handleDarkMode = useCallback((event: ChangeEvent<HTMLInputElement>) => {
@@ -29,4 +29,4 @@ export const DarkModeButton = memo(() => {
       <Switch checked={isDarkMode} onChange={handleDarkMode} inputProps={{ 'aria-label': 'dark-mode' }} />
     </Stack>
   );
-});
+};

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -8,12 +8,12 @@ import { useNewMediaQuery } from '@/hooks/useMediaQuery';
 import { SquareAll } from './squareAll';
 import { TimeDisplay } from './timeDisplay';
 
-const GameStatusDisplay = memo(() => {
+const GameStatusDisplay = () => {
   const gameText = useAtomValue(gameTextAtom);
   return <div>{gameText}</div>;
-});
+};
 
-const SurrenderButton = memo(() => {
+const SurrenderButton = () => {
   const setGameStatus = useSetAtom(gameStatusAtom);
   const isGameFinish = useAtomValue(isGameFinishAtom); //ゲームが終了したらボタンをdisableにする
 
@@ -26,9 +26,9 @@ const SurrenderButton = memo(() => {
       投了
     </Button>
   );
-});
+};
 
-export const Game = memo(() => {
+export const Game = () => {
   // レスポンシブを取得
   const { isSp } = useNewMediaQuery();
 
@@ -43,4 +43,4 @@ export const Game = memo(() => {
       <History />
     </Stack>
   );
-});
+};

--- a/src/components/gameModeSelector.tsx
+++ b/src/components/gameModeSelector.tsx
@@ -3,7 +3,7 @@ import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { memo, useCallback } from 'react';
 
-export const GameModeSelector = memo(() => {
+export const GameModeSelector = () => {
   const boardSizeNum = useAtomValue(boardSizeAtom);
   const boardSizeNumChange = useSetAtom(boardSizeChangeAtom);
 
@@ -27,4 +27,4 @@ export const GameModeSelector = memo(() => {
       <ToggleButton value="5">5目並べ</ToggleButton>
     </ToggleButtonGroup>
   );
-});
+};

--- a/src/components/history.tsx
+++ b/src/components/history.tsx
@@ -5,7 +5,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { historyLengthAtom, historyTextAtom } from '@/globalStates/historyAtoms';
 import { pageAtom, updatePageAtom } from '@/globalStates/pageAtoms';
 
-const TextBox = memo(() => {
+const TextBox = () => {
   const historyText = useAtomValue(historyTextAtom);
   return (
     <Box
@@ -17,9 +17,9 @@ const TextBox = memo(() => {
       {historyText}
     </Box>
   );
-});
+};
 
-const Pages = memo(() => {
+const Pages = () => {
   const historyLength = useAtomValue(historyLengthAtom);
   const page = useAtomValue(pageAtom);
   const updatePage = useSetAtom(updatePageAtom);
@@ -40,9 +40,9 @@ const Pages = memo(() => {
       boundaryCount={1}
     />
   );
-});
+};
 
-const RestartButton = memo(() => {
+const RestartButton = () => {
   const updatePage = useSetAtom(updatePageAtom);
 
   const restart = useCallback(() => {
@@ -54,9 +54,9 @@ const RestartButton = memo(() => {
       はじめから
     </Button>
   );
-});
+};
 
-export const History = memo(() => {
+export const History = () => {
   return (
     <Stack spacing={1} justifyContent="center" alignContent="center">
       <TextBox />
@@ -64,4 +64,4 @@ export const History = memo(() => {
       <RestartButton />
     </Stack>
   );
-});
+};

--- a/src/components/square.tsx
+++ b/src/components/square.tsx
@@ -9,7 +9,7 @@ type Props = {
   num: number;
 };
 
-export const Square = memo(({ onClick, num }: Props) => {
+export const Square = ({ onClick, num }: Props) => {
   const value = useAtomValue(squareValueAtom(num));
   const wonLine = useAtomValue(squareWonLineAtom(num));
   const isGameFinish = useAtomValue(isGameFinishAtom);
@@ -37,4 +37,4 @@ export const Square = memo(({ onClick, num }: Props) => {
       {value}
     </SquareStyle>
   );
-});
+};

--- a/src/components/squareAll.tsx
+++ b/src/components/squareAll.tsx
@@ -8,7 +8,7 @@ import { squareClickAtom } from '@/globalStates/gameStatusAtom';
 /**
  * valueを反映させたsquareを生成
  */
-export const SquareAll = memo(() => {
+export const SquareAll = () => {
   const boardSize = useAtomValue(boardSizeAtom);
   const squareClick = useSetAtom(squareClickAtom);
 
@@ -27,4 +27,4 @@ export const SquareAll = memo(() => {
       ))}
     </PlayBoard>
   );
-});
+};

--- a/src/components/timeDisplay.tsx
+++ b/src/components/timeDisplay.tsx
@@ -3,7 +3,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { timeUpAtom, timeAtom, timeCountDownEffectAtom } from '@/globalStates/timeAtoms';
 import { gameTimeUpAtom } from '@/globalStates/gameStatusAtom';
 
-export const TimeDisplay = memo(() => {
+export const TimeDisplay = () => {
   useAtom(timeCountDownEffectAtom); // カウントダウンのatomEffectを呼び出す
   const time = useAtomValue(timeAtom);
   const timeUp = useAtomValue(timeUpAtom);
@@ -15,4 +15,4 @@ export const TimeDisplay = memo(() => {
   }, [timeUp]);
 
   return <div>{timeUp ? '時間切れ' : `制限時間:${time}秒`}</div>;
-});
+};


### PR DESCRIPTION
React.memoを使うとコンポーネントに名前を付ける必要があるらしく、エラーが出る。
エラー "Component definition is missing display name"

今回の場合は、Stateをグローバル化したことでmemoを使わなくても再レンダリングを抑えられるように設計できたので、React.memoを取り除いた。